### PR TITLE
Epic2-45: Подготовка для экрана Детали под будущие изменения

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/data/db/AppDatabase.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/db/AppDatabase.kt
@@ -5,7 +5,7 @@ import androidx.room.RoomDatabase
 import ru.practicum.android.diploma.data.db.dao.VacancyDao
 import ru.practicum.android.diploma.data.db.entity.VacancyEntity
 
-@Database(version = 4, entities = [VacancyEntity::class], exportSchema = false)
+@Database(version = 5, entities = [VacancyEntity::class], exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun vacancyDao(): VacancyDao
 }

--- a/app/src/main/java/ru/practicum/android/diploma/data/db/AppDatabase.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/db/AppDatabase.kt
@@ -5,7 +5,7 @@ import androidx.room.RoomDatabase
 import ru.practicum.android.diploma.data.db.dao.VacancyDao
 import ru.practicum.android.diploma.data.db.entity.VacancyEntity
 
-@Database(version = 3, entities = [VacancyEntity::class], exportSchema = false)
+@Database(version = 4, entities = [VacancyEntity::class], exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun vacancyDao(): VacancyDao
 }

--- a/app/src/main/java/ru/practicum/android/diploma/data/db/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/db/FavoritesRepositoryImpl.kt
@@ -35,7 +35,7 @@ class FavoritesRepositoryImpl(
     }
 
     override suspend fun getFavoriteById(vacancyId: Long): Boolean {
-        return (getFavouriteByIdRequest(vacancyId) != null)
+        return getFavouriteByIdRequest(vacancyId) != null
     }
 
     private suspend fun getFavouriteByIdRequest(vacancyId: Long): VacancyEntity? {

--- a/app/src/main/java/ru/practicum/android/diploma/data/db/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/db/FavoritesRepositoryImpl.kt
@@ -1,10 +1,11 @@
 package ru.practicum.android.diploma.data.db
 
 import android.util.Log
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
 import ru.practicum.android.diploma.data.converters.VacanciesConverter
-import ru.practicum.android.diploma.data.db.dao.VacancyDao
 import ru.practicum.android.diploma.data.db.entity.VacancyEntity
 import ru.practicum.android.diploma.domain.Resource
 import ru.practicum.android.diploma.domain.favorites.api.FavoritesRepository
@@ -13,13 +14,13 @@ import ru.practicum.android.diploma.util.ResponseCode
 import java.io.IOException
 
 class FavoritesRepositoryImpl(
-    private val vacancyDao: VacancyDao,
+    private val appDatabase: AppDatabase,
     private val converter: VacanciesConverter
 ) : FavoritesRepository {
 
     override fun getFavorites(): Flow<Resource<List<Vacancy>>> = flow {
         try {
-            vacancyDao.getAllFavorites().collect { entities ->
+            appDatabase.vacancyDao().getAllFavorites().collect { entities ->
                 if (entities.isEmpty()) {
                     emit(Resource.Success(emptyList()))
                 } else {
@@ -33,20 +34,32 @@ class FavoritesRepositoryImpl(
         }
     }
 
-    override suspend fun getFavoritesById(vacancyId: Long): Flow<Boolean> = flow {
-        emit(vacancyDao.getFavoritesById(vacancyId).isNotEmpty())
+    override suspend fun getFavoriteById(vacancyId: Long): Flow<Boolean> = flow {
+        val vacancyEntity = getFavouriteByIdRequest(vacancyId)
+        emit(vacancyEntity != null)
+    }
+
+    private suspend fun getFavouriteByIdRequest(vacancyId: Long): VacancyEntity? {
+        return withContext(Dispatchers.IO) {
+            try {
+                appDatabase.vacancyDao().getFavoriteById(vacancyId)
+            } catch (e: IOException) {
+                Log.i("DB", e.toString())
+                null
+            }
+        }
     }
 
     override suspend fun saveVacancy(vacancy: Vacancy) {
-        vacancyDao.addToFavorites(convertToDB(vacancy))
+        appDatabase.vacancyDao().addToFavorites(convertToDB(vacancy))
     }
 
     override suspend fun deleteVacancy(vacancy: Vacancy) {
-        vacancyDao.removeFromFavorites(convertToDB(vacancy))
+        appDatabase.vacancyDao().removeFromFavorites(convertToDB(vacancy))
     }
 
     override suspend fun removeVacancyById(vacancyId: Long) {
-        vacancyDao.removeById(vacancyId)
+        appDatabase.vacancyDao().removeById(vacancyId)
     }
 
     private fun convertFromDB(entity: List<VacancyEntity>) = entity.map(converter::convertFromDBtoVacancy)

--- a/app/src/main/java/ru/practicum/android/diploma/data/db/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/db/FavoritesRepositoryImpl.kt
@@ -33,8 +33,8 @@ class FavoritesRepositoryImpl(
         }
     }
 
-    override suspend fun getFavoritesById(vacancyId: Long): Boolean {
-        return vacancyDao.getFavoritesById(vacancyId).isNotEmpty()
+    override suspend fun getFavoritesById(vacancyId: Long): Flow<Boolean> = flow {
+        emit(vacancyDao.getFavoritesById(vacancyId).isNotEmpty())
     }
 
     override suspend fun saveVacancy(vacancy: Vacancy) {

--- a/app/src/main/java/ru/practicum/android/diploma/data/db/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/db/FavoritesRepositoryImpl.kt
@@ -34,9 +34,8 @@ class FavoritesRepositoryImpl(
         }
     }
 
-    override suspend fun getFavoriteById(vacancyId: Long): Flow<Boolean> = flow {
-        val vacancyEntity = getFavouriteByIdRequest(vacancyId)
-        emit(vacancyEntity != null)
+    override suspend fun getFavoriteById(vacancyId: Long): Boolean {
+        return (getFavouriteByIdRequest(vacancyId) != null)
     }
 
     private suspend fun getFavouriteByIdRequest(vacancyId: Long): VacancyEntity? {

--- a/app/src/main/java/ru/practicum/android/diploma/data/db/dao/VacancyDao.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/db/dao/VacancyDao.kt
@@ -16,12 +16,12 @@ interface VacancyDao {
     @Delete
     suspend fun removeFromFavorites(vacancy: VacancyEntity)
 
-    @Query("DELETE FROM favorite_table WHERE vacancyId = :vacancyId")
+    @Query("DELETE FROM favorites_table WHERE vacancy_id = :vacancyId")
     suspend fun removeById(vacancyId: Long)
 
-    @Query("SELECT * FROM favorite_table ORDER BY timeStamp DESC")
+    @Query("SELECT * FROM favorites_table ORDER BY timeStamp DESC")
     fun getAllFavorites(): Flow<List<VacancyEntity>>
 
-    @Query("SELECT * FROM favorite_table WHERE vacancyId = :vacancyId")
-    fun getFavoritesById(vacancyId: Long): List<VacancyEntity>
+    @Query("SELECT * FROM favorites_table WHERE vacancy_id = :vacancyId")
+    fun getFavoriteById(vacancyId: Long): VacancyEntity
 }

--- a/app/src/main/java/ru/practicum/android/diploma/data/db/entity/VacancyEntity.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/db/entity/VacancyEntity.kt
@@ -1,23 +1,37 @@
 package ru.practicum.android.diploma.data.db.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "favorite_table")
+@Entity(tableName = "favorites_table")
 data class VacancyEntity(
-    @PrimaryKey
+    @PrimaryKey @ColumnInfo(name = "vacancy_id")
     val vacancyId: Long,
+    @ColumnInfo(name = "name")
     val name: String?,
+    @ColumnInfo(name = "area")
     val area: String?,
+    @ColumnInfo(name = "employer")
     val employer: String?,
+    @ColumnInfo(name = "salary")
     val salary: String?,
+    @ColumnInfo(name = "experience")
     val experience: String?,
+    @ColumnInfo(name = "employmentForm")
     val employmentForm: String?,
+    @ColumnInfo(name = "employment")
     val employment: String?,
+    @ColumnInfo(name = "schedule")
     val schedule: String?,
+    @ColumnInfo(name = "description")
     val description: String?,
+    @ColumnInfo(name = "keySkills")
     val keySkills: String?,
+    @ColumnInfo(name = "alternateUrl")
     val alternateUrl: String?,
+    @ColumnInfo(name = "address")
     val address: String,
+    @ColumnInfo(name = "timeStamp")
     val timeStamp: Long = System.currentTimeMillis()
 )

--- a/app/src/main/java/ru/practicum/android/diploma/data/db/entity/VacancyEntity.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/db/entity/VacancyEntity.kt
@@ -18,7 +18,7 @@ data class VacancyEntity(
     val salary: String?,
     @ColumnInfo(name = "experience")
     val experience: String?,
-    @ColumnInfo(name = "employmentForm")
+    @ColumnInfo(name = "employment_form")
     val employmentForm: String?,
     @ColumnInfo(name = "employment")
     val employment: String?,
@@ -26,9 +26,9 @@ data class VacancyEntity(
     val schedule: String?,
     @ColumnInfo(name = "description")
     val description: String?,
-    @ColumnInfo(name = "keySkills")
+    @ColumnInfo(name = "key_skills")
     val keySkills: String?,
-    @ColumnInfo(name = "alternateUrl")
+    @ColumnInfo(name = "alternate_url")
     val alternateUrl: String?,
     @ColumnInfo(name = "address")
     val address: String,

--- a/app/src/main/java/ru/practicum/android/diploma/data/dto/VacancyDetailsResponse.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/dto/VacancyDetailsResponse.kt
@@ -1,3 +1,0 @@
-package ru.practicum.android.diploma.data.dto
-
-data class VacancyDetailsResponse(val vacancyDto: VacancyDto) : Response()

--- a/app/src/main/java/ru/practicum/android/diploma/data/dto/VacancyDto.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/dto/VacancyDto.kt
@@ -20,4 +20,4 @@ data class VacancyDto(
     @SerializedName("alternate_url")
     val alternateUrl: String?,
     val address: AddressDto?
-)
+) : Response()

--- a/app/src/main/java/ru/practicum/android/diploma/data/network/HhApi.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/network/HhApi.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Query
 import retrofit2.http.QueryMap
 import ru.practicum.android.diploma.BuildConfig
 import ru.practicum.android.diploma.data.dto.VacanciesResponseDto
-import ru.practicum.android.diploma.data.dto.VacancyDetailsResponse
+import ru.practicum.android.diploma.data.dto.VacancyDto
 
 interface HhApi {
     @Headers(
@@ -32,5 +32,5 @@ interface HhApi {
         "HH-User-Agent: heheru (heheru2025@gmail.com)"
     )
     @GET("/vacancies/{vacancy_id}")
-    suspend fun getVacancyDetails(@Path("vacancy_id") id: String): VacancyDetailsResponse
+    suspend fun getVacancyDetails(@Path("vacancy_id") id: String): VacancyDto
 }

--- a/app/src/main/java/ru/practicum/android/diploma/data/vacancydetails/VacancyDetailsRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/vacancydetails/VacancyDetailsRepositoryImpl.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import ru.practicum.android.diploma.data.NetworkClient
 import ru.practicum.android.diploma.data.converters.VacanciesConverter
-import ru.practicum.android.diploma.data.dto.VacancyDetailsResponse
+import ru.practicum.android.diploma.data.dto.VacancyDto
 import ru.practicum.android.diploma.domain.Resource
 import ru.practicum.android.diploma.domain.models.Vacancy
 import ru.practicum.android.diploma.domain.vacancydetails.api.VacancyDetailsRepository
@@ -24,8 +24,8 @@ class VacancyDetailsRepositoryImpl(
             ResponseCode.SERVER_ERROR.code -> emit(Resource.Error(ResponseCode.SERVER_ERROR.code))
 
             ResponseCode.SUCCESS.code -> {
-                with(response as VacancyDetailsResponse) {
-                    val data = vacanciesConverter.convertFull(response.vacancyDto)
+                with(response as VacancyDto) {
+                    val data = vacanciesConverter.convertFull(response)
                     // Тут нужно будет проверять находится ли вакансия в избранном или нет
                     emit(Resource.Success(data))
                 }

--- a/app/src/main/java/ru/practicum/android/diploma/di/ViewModelModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/di/ViewModelModule.kt
@@ -11,8 +11,8 @@ val viewModelModule = module {
         SearchViewModel(get())
     }
 
-    viewModel {
-        VacancyViewModel(get(), get())
+    viewModel { (vacancyId: Long) ->
+        VacancyViewModel(vacancyId, get(), get())
     }
 
     viewModel {

--- a/app/src/main/java/ru/practicum/android/diploma/domain/favorites/api/FavoritesInteractor.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/favorites/api/FavoritesInteractor.kt
@@ -7,7 +7,7 @@ import ru.practicum.android.diploma.domain.models.Vacancy
 interface FavoritesInteractor {
     fun getFavorites(): Flow<Resource<List<Vacancy>>>
 
-    suspend fun getFavoritesById(vacancyId: Long): Boolean
+    suspend fun getFavoritesById(vacancyId: Long): Flow<Boolean>
     suspend fun saveVacancy(vacancy: Vacancy)
     suspend fun deleteVacancy(vacancy: Vacancy)
     suspend fun removeVacancyById(vacancyId: Long)

--- a/app/src/main/java/ru/practicum/android/diploma/domain/favorites/api/FavoritesInteractor.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/favorites/api/FavoritesInteractor.kt
@@ -7,7 +7,7 @@ import ru.practicum.android.diploma.domain.models.Vacancy
 interface FavoritesInteractor {
     fun getFavorites(): Flow<Resource<List<Vacancy>>>
 
-    suspend fun getFavoritesById(vacancyId: Long): Flow<Boolean>
+    suspend fun getFavoriteById(vacancyId: Long): Flow<Boolean>
     suspend fun saveVacancy(vacancy: Vacancy)
     suspend fun deleteVacancy(vacancy: Vacancy)
     suspend fun removeVacancyById(vacancyId: Long)

--- a/app/src/main/java/ru/practicum/android/diploma/domain/favorites/api/FavoritesInteractor.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/favorites/api/FavoritesInteractor.kt
@@ -7,7 +7,7 @@ import ru.practicum.android.diploma.domain.models.Vacancy
 interface FavoritesInteractor {
     fun getFavorites(): Flow<Resource<List<Vacancy>>>
 
-    suspend fun getFavoriteById(vacancyId: Long): Flow<Boolean>
+    suspend fun getFavoriteById(vacancyId: Long): Boolean
     suspend fun saveVacancy(vacancy: Vacancy)
     suspend fun deleteVacancy(vacancy: Vacancy)
     suspend fun removeVacancyById(vacancyId: Long)

--- a/app/src/main/java/ru/practicum/android/diploma/domain/favorites/api/FavoritesRepository.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/favorites/api/FavoritesRepository.kt
@@ -7,7 +7,7 @@ import ru.practicum.android.diploma.domain.models.Vacancy
 interface FavoritesRepository {
     fun getFavorites(): Flow<Resource<List<Vacancy>>>
 
-    suspend fun getFavoritesById(vacancyId: Long): Boolean
+    suspend fun getFavoritesById(vacancyId: Long): Flow<Boolean>
     suspend fun saveVacancy(vacancy: Vacancy)
     suspend fun deleteVacancy(vacancy: Vacancy)
     suspend fun removeVacancyById(vacancyId: Long)

--- a/app/src/main/java/ru/practicum/android/diploma/domain/favorites/api/FavoritesRepository.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/favorites/api/FavoritesRepository.kt
@@ -7,7 +7,7 @@ import ru.practicum.android.diploma.domain.models.Vacancy
 interface FavoritesRepository {
     fun getFavorites(): Flow<Resource<List<Vacancy>>>
 
-    suspend fun getFavoriteById(vacancyId: Long): Flow<Boolean>
+    suspend fun getFavoriteById(vacancyId: Long): Boolean
     suspend fun saveVacancy(vacancy: Vacancy)
     suspend fun deleteVacancy(vacancy: Vacancy)
     suspend fun removeVacancyById(vacancyId: Long)

--- a/app/src/main/java/ru/practicum/android/diploma/domain/favorites/api/FavoritesRepository.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/favorites/api/FavoritesRepository.kt
@@ -7,7 +7,7 @@ import ru.practicum.android.diploma.domain.models.Vacancy
 interface FavoritesRepository {
     fun getFavorites(): Flow<Resource<List<Vacancy>>>
 
-    suspend fun getFavoritesById(vacancyId: Long): Flow<Boolean>
+    suspend fun getFavoriteById(vacancyId: Long): Flow<Boolean>
     suspend fun saveVacancy(vacancy: Vacancy)
     suspend fun deleteVacancy(vacancy: Vacancy)
     suspend fun removeVacancyById(vacancyId: Long)

--- a/app/src/main/java/ru/practicum/android/diploma/domain/favorites/impl/FavoritesInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/favorites/impl/FavoritesInteractorImpl.kt
@@ -14,8 +14,10 @@ class FavoritesInteractorImpl(
         favoritesRepository.getFavorites()
     }
 
-    override suspend fun getFavoritesById(vacancyId: Long): Boolean =
-        favoritesRepository.getFavoritesById(vacancyId)
+    override suspend fun getFavoritesById(vacancyId: Long): Flow<Boolean> {
+        return favoritesRepository.getFavoritesById(vacancyId)
+    }
+
 
     override suspend fun saveVacancy(vacancy: Vacancy) {
         favoritesRepository.saveVacancy(vacancy)

--- a/app/src/main/java/ru/practicum/android/diploma/domain/favorites/impl/FavoritesInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/favorites/impl/FavoritesInteractorImpl.kt
@@ -14,8 +14,8 @@ class FavoritesInteractorImpl(
         favoritesRepository.getFavorites()
     }
 
-    override suspend fun getFavoritesById(vacancyId: Long): Flow<Boolean> {
-        return favoritesRepository.getFavoritesById(vacancyId)
+    override suspend fun getFavoriteById(vacancyId: Long): Flow<Boolean> {
+        return favoritesRepository.getFavoriteById(vacancyId)
     }
 
     override suspend fun saveVacancy(vacancy: Vacancy) {

--- a/app/src/main/java/ru/practicum/android/diploma/domain/favorites/impl/FavoritesInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/favorites/impl/FavoritesInteractorImpl.kt
@@ -14,7 +14,7 @@ class FavoritesInteractorImpl(
         favoritesRepository.getFavorites()
     }
 
-    override suspend fun getFavoriteById(vacancyId: Long): Flow<Boolean> {
+    override suspend fun getFavoriteById(vacancyId: Long): Boolean {
         return favoritesRepository.getFavoriteById(vacancyId)
     }
 

--- a/app/src/main/java/ru/practicum/android/diploma/domain/favorites/impl/FavoritesInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/favorites/impl/FavoritesInteractorImpl.kt
@@ -18,7 +18,6 @@ class FavoritesInteractorImpl(
         return favoritesRepository.getFavoritesById(vacancyId)
     }
 
-
     override suspend fun saveVacancy(vacancy: Vacancy) {
         favoritesRepository.saveVacancy(vacancy)
     }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/favourites/fragment/FavouritesFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/favourites/fragment/FavouritesFragment.kt
@@ -63,7 +63,7 @@ class FavouritesFragment : Fragment() {
     private fun openVacancyDetails(vacancyId: Long) {
         findNavController().navigate(
             R.id.action_searchFragment_to_vacancyFragment2,
-            VacancyFragment.createArgs(vacancyId)
+            VacancyFragment.createArgs(vacancyId, true)
         )
     }
 

--- a/app/src/main/java/ru/practicum/android/diploma/ui/favourites/viewmodel/FavouritesViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/favourites/viewmodel/FavouritesViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import ru.practicum.android.diploma.domain.Resource
 import ru.practicum.android.diploma.domain.favorites.api.FavoritesInteractor
@@ -29,7 +30,7 @@ class FavouritesViewModel(
     }
 
     private fun loadFavorites() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             interactor.getFavorites()
                 .collect { resource ->
                     _favoriteVacancies.value = resource

--- a/app/src/main/java/ru/practicum/android/diploma/ui/search/fragment/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/search/fragment/SearchFragment.kt
@@ -136,7 +136,7 @@ class SearchFragment : Fragment() {
     private fun openVacancyDetails(vacancyId: Long) {
         findNavController().navigate(
             R.id.action_searchFragment_to_vacancyFragment2,
-            VacancyFragment.createArgs(vacancyId)
+            VacancyFragment.createArgs(vacancyId, false)
         )
     }
 
@@ -154,6 +154,7 @@ class SearchFragment : Fragment() {
                 textView.isVisible = true
 
             }
+
             is SearchResult.NoConnection -> {
                 Toast.makeText(
                     requireContext(),
@@ -161,6 +162,7 @@ class SearchFragment : Fragment() {
                     Toast.LENGTH_LONG
                 ).show()
             }
+
             is SearchResult.Loading -> {
                 binding.progressBarSearch.isVisible = true
             }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/fragment/VacancyFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/fragment/VacancyFragment.kt
@@ -28,7 +28,7 @@ class VacancyFragment : Fragment() {
     значит запрос делаем только в БД,
     иначе -> идем в сеть, потом идем в БД проверить она в избранном или нет -> обновить иконку избранного
      */
-    private var isNeedGetFRomDB: Boolean = false
+    private var isFromFavouritesScreen: Boolean = false
 
     private val viewModel: VacancyViewModel by viewModel { parametersOf(vacancyId) }
 
@@ -51,7 +51,7 @@ class VacancyFragment : Fragment() {
 
     private fun getVacancyId() {
         vacancyId = requireArguments().getLong(ARGS_VACANCY_ID)
-        isNeedGetFRomDB = requireArguments().getBoolean(IS_NEED_GET_FROM_DB)
+        isFromFavouritesScreen = requireArguments().getBoolean(FROM_FAVOURITES_SCREEN)
     }
 
     private fun setupListeners() {
@@ -127,9 +127,9 @@ class VacancyFragment : Fragment() {
     companion object {
         // private const val DEFAULT_VACANCY_ID: Long = 123L
         private const val ARGS_VACANCY_ID = "vacancy_id"
-        private const val IS_NEED_GET_FROM_DB = "is_need_get_from_db"
+        private const val FROM_FAVOURITES_SCREEN = "from_favourites_screen"
 
-        fun createArgs(vacancyId: Long, isNeedGetFromDB: Boolean): Bundle =
-            bundleOf(ARGS_VACANCY_ID to vacancyId, IS_NEED_GET_FROM_DB to isNeedGetFromDB)
+        fun createArgs(vacancyId: Long, isFromFavouritesScreen: Boolean): Bundle =
+            bundleOf(ARGS_VACANCY_ID to vacancyId, FROM_FAVOURITES_SCREEN to isFromFavouritesScreen)
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/fragment/VacancyFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/fragment/VacancyFragment.kt
@@ -22,6 +22,14 @@ class VacancyFragment : Fragment() {
     private val binding get() = _binding!!
 
     private var vacancyId by Delegates.notNull<Long>()
+
+    /*
+    переменная-индиктор: если из предыдущего экрана (Поиск или Избранное) она получает значение true,
+    значит запрос делаем только в БД,
+    иначе -> идем в сеть, потом идем в БД проверить она в избранном или нет -> обновить иконку избранного
+     */
+    private var isNeedGetFRomDB: Boolean = false
+
     private val viewModel: VacancyViewModel by viewModel { parametersOf(vacancyId) }
 
     override fun onCreateView(
@@ -43,6 +51,7 @@ class VacancyFragment : Fragment() {
 
     private fun getVacancyId() {
         vacancyId = requireArguments().getLong(ARGS_VACANCY_ID)
+        isNeedGetFRomDB = requireArguments().getBoolean(IS_NEED_GET_FROM_DB)
     }
 
     private fun setupListeners() {
@@ -118,8 +127,9 @@ class VacancyFragment : Fragment() {
     companion object {
         // private const val DEFAULT_VACANCY_ID: Long = 123L
         private const val ARGS_VACANCY_ID = "vacancy_id"
+        private const val IS_NEED_GET_FROM_DB = "is_need_get_from_db"
 
-        fun createArgs(vacancyId: Long): Bundle =
-            bundleOf(ARGS_VACANCY_ID to vacancyId)
+        fun createArgs(vacancyId: Long, isNeedGetFromDB: Boolean): Bundle =
+            bundleOf(ARGS_VACANCY_ID to vacancyId, IS_NEED_GET_FROM_DB to isNeedGetFromDB)
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/fragment/VacancyFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/fragment/VacancyFragment.kt
@@ -1,36 +1,28 @@
 package ru.practicum.android.diploma.ui.vacancydetails.fragment
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.parametersOf
 import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.databinding.FragmentVacancyBinding
+import ru.practicum.android.diploma.domain.models.Vacancy
+import ru.practicum.android.diploma.ui.vacancydetails.state.VacancyDetailsScreenState
 import ru.practicum.android.diploma.ui.vacancydetails.viewmodel.VacancyViewModel
+import kotlin.properties.Delegates
 
 class VacancyFragment : Fragment() {
 
     private var _binding: FragmentVacancyBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: VacancyViewModel by viewModels()
-
-    // Временная заглушка + fix detekt
-    companion object {
-        private const val DEFAULT_VACANCY_ID: Long = 123L
-
-        private const val ARGS_FACT = "vacancy"
-
-        fun createArgs(vacancyId: Long): Bundle =
-            bundleOf(ARGS_FACT to vacancyId)
-    }
-
-    private val vacancyId: Long = DEFAULT_VACANCY_ID
+    private var vacancyId by Delegates.notNull<Long>()
+    private val viewModel: VacancyViewModel by viewModel { parametersOf(vacancyId) }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -44,31 +36,46 @@ class VacancyFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+
+
+        getVacancyId()
+        setupListeners()
+        observeViewModel()
+    }
+
+    private fun getVacancyId() {
+        vacancyId = requireArguments().getLong(ARGS_VACANCY_ID)
+    }
+
+
+    private fun setupListeners() {
+        binding.toolbar.setNavigationOnClickListener { findNavController().popBackStack() }
+
+        // Этот метод нужно вынести в data-слой
+
+//        binding.imageViewSharing.setOnClickListener {
+//            viewModel.vacancy.value?.let { vacancy ->
+//                val shareText = "${vacancy.name ?: "Вакансия"}\n\n${vacancy.alternateUrl ?: ""}"
+//                val shareIntent = Intent(Intent.ACTION_SEND).apply {
+//                    type = "text/plain"
+//                    putExtra(Intent.EXTRA_TEXT, shareText)
+//                }
+//                startActivity(Intent.createChooser(shareIntent, ""))
+//            }
+//        }
+
+        binding.imageViewFavorites.setOnClickListener {
+            viewModel.onFavoriteClicked()
+        }
+    }
+
+    private fun observeViewModel() {
         viewModel.isFavorite.observe(viewLifecycleOwner) { isFavorite ->
             updateFavoriteIcon(isFavorite)
         }
 
-        backButton()
-        shareButton()
-        favoriteButton(vacancyId)
-    }
-
-    private fun backButton() = binding.toolbar.setNavigationOnClickListener { findNavController().popBackStack() }
-
-    private fun favoriteButton(vacancyId: Long) = binding.imageViewFavorites.setOnClickListener {
-        viewModel.onFavoriteClicked()
-    }
-
-    private fun shareButton() {
-        binding.imageViewSharing.setOnClickListener {
-            viewModel.vacancy.value?.let { vacancy ->
-                val shareText = "${vacancy.name ?: "Вакансия"}\n\n${vacancy.alternateUrl ?: ""}"
-                val shareIntent = Intent(Intent.ACTION_SEND).apply {
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_TEXT, shareText)
-                }
-                startActivity(Intent.createChooser(shareIntent, ""))
-            }
+        viewModel.vacancyDetailsScreenState.observe(viewLifecycleOwner) { state ->
+            render(state)
         }
     }
 
@@ -79,5 +86,33 @@ class VacancyFragment : Fragment() {
             R.drawable.ic_like_off_24
         }
         binding.imageViewFavorites.setImageResource(resId)
+    }
+
+
+    private fun render(state: VacancyDetailsScreenState) {
+        when (state) {
+            is VacancyDetailsScreenState.Loading -> showLoading()
+            is VacancyDetailsScreenState.ServerError -> showServerErrorPlaceholder()
+            is VacancyDetailsScreenState.NotFoundError -> showNotFoundPlaceholder()
+            is VacancyDetailsScreenState.Content -> showVacancyDetails(state.vacancy)
+        }
+    }
+
+    private fun showLoading() {}
+    private fun showServerErrorPlaceholder() {}
+    private fun showNotFoundPlaceholder() {}
+    private fun showVacancyDetails(vacancy: Vacancy) {
+        bindData(vacancy)
+    }
+
+    private fun bindData(vacancy: Vacancy) {}
+
+    // Временная заглушка + fix detekt
+    companion object {
+        // private const val DEFAULT_VACANCY_ID: Long = 123L
+        private const val ARGS_VACANCY_ID = "vacancy_id"
+
+        fun createArgs(vacancyId: Long): Bundle =
+            bundleOf(ARGS_VACANCY_ID to vacancyId)
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/fragment/VacancyFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/fragment/VacancyFragment.kt
@@ -36,8 +36,6 @@ class VacancyFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-
-
         getVacancyId()
         setupListeners()
         observeViewModel()
@@ -46,7 +44,6 @@ class VacancyFragment : Fragment() {
     private fun getVacancyId() {
         vacancyId = requireArguments().getLong(ARGS_VACANCY_ID)
     }
-
 
     private fun setupListeners() {
         binding.toolbar.setNavigationOnClickListener { findNavController().popBackStack() }
@@ -88,7 +85,6 @@ class VacancyFragment : Fragment() {
         binding.imageViewFavorites.setImageResource(resId)
     }
 
-
     private fun render(state: VacancyDetailsScreenState) {
         when (state) {
             is VacancyDetailsScreenState.Loading -> showLoading()
@@ -98,14 +94,25 @@ class VacancyFragment : Fragment() {
         }
     }
 
-    private fun showLoading() {}
-    private fun showServerErrorPlaceholder() {}
-    private fun showNotFoundPlaceholder() {}
+    private fun showLoading() {
+        // Делаем видимым только прогрессбар
+    }
+
+    private fun showServerErrorPlaceholder() {
+        // Делаем видимым только плейсхолдер
+    }
+
+    private fun showNotFoundPlaceholder() {
+        // Делаем видимым только плейсхолдер
+    }
+
     private fun showVacancyDetails(vacancy: Vacancy) {
         bindData(vacancy)
     }
 
-    private fun bindData(vacancy: Vacancy) {}
+    private fun bindData(vacancy: Vacancy) {
+        // Здесь биндим данные в соответствующие поля
+    }
 
     // Временная заглушка + fix detekt
     companion object {

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/state/VacancyDetailsScreenState.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/state/VacancyDetailsScreenState.kt
@@ -5,5 +5,6 @@ import ru.practicum.android.diploma.domain.models.Vacancy
 sealed interface VacancyDetailsScreenState {
     data object Loading : VacancyDetailsScreenState
     class Content(val vacancy: Vacancy) : VacancyDetailsScreenState
-    data object Error : VacancyDetailsScreenState
+    data object ServerError : VacancyDetailsScreenState
+    data object NotFoundError : VacancyDetailsScreenState
 }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
@@ -46,16 +46,15 @@ class VacancyViewModel(
         }
     }
 
-    // ПОКА ЗАКОММЕНТИРУЮ - НАДО ВЫЯСНИТЬ ПОЧЕМУ НЕ РАБОТАЕТ
     // Метод для проверки, добавлена ли вакансия в избранное,
     // вызвать в методе getVacancy после успешного получения вакансии
-//    private fun checkFavoriteStatus() {
-//        viewModelScope.launch {
-//            favoritesInteractor.getFavoritesById(currentVacancyId).collect { favouriteStatus ->
-//                _isFavorite.postValue(favouriteStatus)
-//            }
-//        }
-//    }
+    private fun checkFavoriteStatus() {
+        viewModelScope.launch {
+            favoritesInteractor.getFavoriteById(currentVacancyId).collect { favouriteStatus ->
+                _isFavorite.postValue(favouriteStatus)
+            }
+        }
+    }
 
     private fun searchVacancyDetails() {
         _vacancyDetailsScreenState.postValue(VacancyDetailsScreenState.Loading)
@@ -78,8 +77,7 @@ class VacancyViewModel(
             is Resource.Success -> {
                 if (resource.value != null) {
                     vacancy = resource.value
-                    // пока не работает checkFavoriteStatus
-                    // checkFavoriteStatus()
+                    checkFavoriteStatus()
                     _vacancyDetailsScreenState.postValue(VacancyDetailsScreenState.Content(resource.value))
                 } else {
                     // Проверить, что это точно работает

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
@@ -28,6 +28,7 @@ class VacancyViewModel(
 
     init {
         // здесь будем загружать детали вакансии
+        checkFavoriteStatus()
         searchVacancyDetails()
     }
 
@@ -50,9 +51,7 @@ class VacancyViewModel(
     // вызвать в методе getVacancy после успешного получения вакансии
     private fun checkFavoriteStatus() {
         viewModelScope.launch {
-            favoritesInteractor.getFavoriteById(currentVacancyId).collect { favouriteStatus ->
-                _isFavorite.postValue(favouriteStatus)
-            }
+            _isFavorite.postValue(favoritesInteractor.getFavoriteById(currentVacancyId))
         }
     }
 
@@ -77,7 +76,7 @@ class VacancyViewModel(
             is Resource.Success -> {
                 if (resource.value != null) {
                     vacancy = resource.value
-                    checkFavoriteStatus()
+
                     _vacancyDetailsScreenState.postValue(VacancyDetailsScreenState.Content(resource.value))
                 } else {
                     // Проверить, что это точно работает

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
@@ -20,10 +20,6 @@ class VacancyViewModel(
 
     private var vacancy: Vacancy? = null
 
-    //    // Временное решение для кнопок "Поделиться" и "Избранное"
-//    private val _vacancy = MutableLiveData<Vacancy>()
-//    val vacancy: LiveData<Vacancy> get() = _vacancy
-
     private val _vacancyDetailsScreenState = MutableLiveData<VacancyDetailsScreenState>()
     val vacancyDetailsScreenState: LiveData<VacancyDetailsScreenState> = _vacancyDetailsScreenState
 
@@ -31,10 +27,7 @@ class VacancyViewModel(
     val isFavorite: LiveData<Boolean> get() = _isFavorite
 
 
-    // Временно решение для метода getFavorites, чтобы пройти проверку
-    // потом удалить!
     init {
-        checkFavoriteStatus()
         // здесь будем загружать детали вакансии
         searchVacancyDetails()
     }
@@ -59,10 +52,6 @@ class VacancyViewModel(
     // вызвать в методе getVacancy после успешного получения вакансии
     private fun checkFavoriteStatus() {
         viewModelScope.launch {
-//            _vacancy.value?.let {
-//                val result = favoritesInteractor.getFavoritesById(it.vacancyId)
-//                _isFavorite.postValue(result)
-//            }
             favoritesInteractor.getFavoritesById(currentVacancyId).collect { favouriteStatus ->
                 _isFavorite.postValue(favouriteStatus)
             }
@@ -84,16 +73,17 @@ class VacancyViewModel(
             is Resource.Error -> {
                 if (resource.errorCode == ResponseCode.SERVER_ERROR.code) {
                     _vacancyDetailsScreenState.postValue(VacancyDetailsScreenState.ServerError)
-                } else {
-                    // Проверить, что это точно работает
-                    _vacancyDetailsScreenState.postValue(VacancyDetailsScreenState.NotFoundError)
                 }
             }
 
             is Resource.Success -> {
                 if (resource.value != null) {
                     vacancy = resource.value
+                    checkFavoriteStatus()
                     _vacancyDetailsScreenState.postValue(VacancyDetailsScreenState.Content(resource.value))
+                } else {
+                    // Проверить, что это точно работает
+                    _vacancyDetailsScreenState.postValue(VacancyDetailsScreenState.NotFoundError)
                 }
             }
         }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
@@ -46,15 +46,16 @@ class VacancyViewModel(
         }
     }
 
+    // ПОКА ЗАКОММЕНТИРУЮ - НАДО ВЫЯСНИТЬ ПОЧЕМУ НЕ РАБОТАЕТ
     // Метод для проверки, добавлена ли вакансия в избранное,
     // вызвать в методе getVacancy после успешного получения вакансии
-    private fun checkFavoriteStatus() {
-        viewModelScope.launch {
-            favoritesInteractor.getFavoritesById(currentVacancyId).collect { favouriteStatus ->
-                _isFavorite.postValue(favouriteStatus)
-            }
-        }
-    }
+//    private fun checkFavoriteStatus() {
+//        viewModelScope.launch {
+//            favoritesInteractor.getFavoritesById(currentVacancyId).collect { favouriteStatus ->
+//                _isFavorite.postValue(favouriteStatus)
+//            }
+//        }
+//    }
 
     private fun searchVacancyDetails() {
         _vacancyDetailsScreenState.postValue(VacancyDetailsScreenState.Loading)
@@ -78,7 +79,7 @@ class VacancyViewModel(
                 if (resource.value != null) {
                     vacancy = resource.value
                     // пока не работает checkFavoriteStatus
-                    //checkFavoriteStatus()
+                    // checkFavoriteStatus()
                     _vacancyDetailsScreenState.postValue(VacancyDetailsScreenState.Content(resource.value))
                 } else {
                     // Проверить, что это точно работает

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
@@ -28,7 +28,7 @@ class VacancyViewModel(
 
     init {
         // здесь будем загружать детали вакансии
-        // searchVacancyDetails()
+        searchVacancyDetails()
     }
 
     // Обработка нажатия на кнопку Избранное

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
@@ -28,7 +28,7 @@ class VacancyViewModel(
 
     init {
         // здесь будем загружать детали вакансии
-        searchVacancyDetails()
+        // searchVacancyDetails()
     }
 
     // Обработка нажатия на кнопку Избранное

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
@@ -26,12 +26,10 @@ class VacancyViewModel(
     private val _isFavorite = MutableLiveData(false)
     val isFavorite: LiveData<Boolean> get() = _isFavorite
 
-
     init {
         // здесь будем загружать детали вакансии
         searchVacancyDetails()
     }
-
 
     // Обработка нажатия на кнопку Избранное
     fun onFavoriteClicked() {

--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancydetails/viewmodel/VacancyViewModel.kt
@@ -77,7 +77,8 @@ class VacancyViewModel(
             is Resource.Success -> {
                 if (resource.value != null) {
                     vacancy = resource.value
-                    checkFavoriteStatus()
+                    // пока не работает checkFavoriteStatus
+                    //checkFavoriteStatus()
                     _vacancyDetailsScreenState.postValue(VacancyDetailsScreenState.Content(resource.value))
                 } else {
                     // Проверить, что это точно работает

--- a/app/src/main/java/ru/practicum/android/diploma/util/ResponseCode.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/util/ResponseCode.kt
@@ -3,6 +3,7 @@ package ru.practicum.android.diploma.util
 private const val SUCCESS_CODE: Int = 200
 private const val SERVER_ERROR_CODE: Int = 500
 private const val NO_INTERNET_CODE: Int = -1
+private const val NOT_FOUND_CODE = 404
 private const val DATABASE_ERROR_CODE = 999
 
 enum class ResponseCode(val code: Int, val description: String) {
@@ -10,6 +11,7 @@ enum class ResponseCode(val code: Int, val description: String) {
     SUCCESS(SUCCESS_CODE, "Запрос выполнен"),
     SERVER_ERROR(SERVER_ERROR_CODE, "Проблемы с сервером"),
     NO_INTERNET(NO_INTERNET_CODE, "Отсутствие интернета"),
+    NOT_FOUND(NOT_FOUND_CODE, "Данные не найдены"),
     DATABASE_ERROR(DATABASE_ERROR_CODE, "Ошибка базы данных");
 
     companion object {


### PR DESCRIPTION
- Добавил новую зависимость в VacancyViewModel. Обновил di-файл.
- Переписал обработку результата сетевого запроса во viewmodel.
- Добавлена новая константа "NOT_FOUND".
- Пофиксил немного изменил работу методов onFavoriteClicked() и checkFavoriteStatus().

====================================

Изменения в коде фрагмента:

Почищен метод onViewCreated() - оставлены только главные методы:
1. Метод для получения id вакансии из аргументов фрагмента.
2. Настройка слушателей на кнопки.
3. Подписка на LiveData.

Создан метод для переключения состояний экрана. И сами методы отображения этих состояний. В них рекомендуется установить видимость нужных элементов на экране.


Добавлена передача аргумента между экранами Поиск -> Детали и Избранное -> Детали
чтобы экран Детали понимал, из какого экрана был переход


_Планируется такая реализация:_

> Из экрана Поиск и Избранное будет передаваться аргумент на экран детали.
> 
> Поиск передает значение false а Избранное передает true
> 
> Экран Детали получает этот аргумент и исходя из его значения действует так:
> 
> 1) если false то делать запрос в сеть, а потом смотреть в БД есть ли там вакансия с таким id и в случае чего отображать сердечко. Если из сети пришел статус "не найдено" (вакансию удалили), а после запроса в БД с этим id обнаружили что она там есть - удалить ее из БД 
> 
> 2) если true - данные о вакансии получать только из БД (не из сети)