### PR TITLE
Epic1-28: Постраничная загрузка результатов поискового запроса («пагинация»)

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/data/NetworkClient.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/NetworkClient.kt
@@ -4,6 +4,6 @@ import ru.practicum.android.diploma.data.dto.Response
 
 interface NetworkClient {
     // suspend fun doRequest(dto: Any): Response
-    suspend fun doRequestVacancies(options: HashMap<String, Int>,text: String?): Response
+    suspend fun doRequestVacancies(text: String?, options: HashMap<String, Int>): Response
     suspend fun doRequestVacancyDetails(vacancyId: String): Response
 }

--- a/app/src/main/java/ru/practicum/android/diploma/data/NetworkClient.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/NetworkClient.kt
@@ -3,6 +3,7 @@ package ru.practicum.android.diploma.data
 import ru.practicum.android.diploma.data.dto.Response
 
 interface NetworkClient {
-    suspend fun doRequestVacancies(text: String?): Response
+    // suspend fun doRequest(dto: Any): Response
+    suspend fun doRequestVacancies(options: HashMap<String, Int>,text: String?): Response
     suspend fun doRequestVacancyDetails(vacancyId: String): Response
 }

--- a/app/src/main/java/ru/practicum/android/diploma/data/converters/VacanciesConverter.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/converters/VacanciesConverter.kt
@@ -22,15 +22,22 @@ import ru.practicum.android.diploma.domain.models.Salary
 import ru.practicum.android.diploma.domain.models.Schedule
 import ru.practicum.android.diploma.domain.models.Skill
 import ru.practicum.android.diploma.domain.models.Vacancy
+import ru.practicum.android.diploma.domain.models.VacancyResponse
 import ru.practicum.android.diploma.util.format.JsonUtils
 import ru.practicum.android.diploma.util.format.JsonUtils.deserializeField
 
 class VacanciesConverter {
 
-    fun convertCut(response: VacanciesResponseDto): List<Vacancy> {
-        return response.items.map {
-            it.toVacancyCut()
-        }
+    fun convertCut(response: VacanciesResponseDto): VacancyResponse {
+//        response.items.map {
+//            it.toVacancyCut()
+//        }
+        return VacancyResponse(
+            found = response.found,
+            response.items.map { it.toVacancyCut() },
+            page = response.page,
+            pages = response.pages
+        )
     }
 
     // для запроса деталей вакансии (задача 30)

--- a/app/src/main/java/ru/practicum/android/diploma/data/dto/VacanciesResponseDto.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/dto/VacanciesResponseDto.kt
@@ -2,5 +2,7 @@ package ru.practicum.android.diploma.data.dto
 
 class VacanciesResponseDto(
     val found: Int,
-    val items: List<VacancyDto>
+    val items: List<VacancyDto>,
+    val page: Int,
+    val pages: Int
 ) : Response()

--- a/app/src/main/java/ru/practicum/android/diploma/data/network/HhApi.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/network/HhApi.kt
@@ -4,6 +4,7 @@ import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.Path
 import retrofit2.http.Query
+import retrofit2.http.QueryMap
 import ru.practicum.android.diploma.BuildConfig
 import ru.practicum.android.diploma.data.dto.VacanciesResponseDto
 import ru.practicum.android.diploma.data.dto.VacancyDetailsResponse
@@ -16,11 +17,13 @@ interface HhApi {
     @GET("vacancies")
     suspend fun searchVacancies(
         @Query("text") text: String?,
+        @QueryMap options: Map<String, Int>,
+//        @Query("text") text: String,
 //        @Query("area") area: String? = null,
 //        @Query("industry") industry: String? = null,
 //        @Query("salary") salary: Int? = null,
 //        @Query("only_with_salary") onlyWithSalary: Boolean = false,
-//        @Query("per_page") perPage: Int = 20,
+        @Query("per_page") perPage: Int = 20
 //        @Query("page") page: Int = 0
     ): VacanciesResponseDto
 

--- a/app/src/main/java/ru/practicum/android/diploma/data/network/RetrofitNetworkClient.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/network/RetrofitNetworkClient.kt
@@ -17,14 +17,14 @@ class RetrofitNetworkClient(
 
     private val isConnected = CheckNetworkConnect.isNetworkAvailable(context)
 
-    override suspend fun doRequestVacancies(text: String?): Response {
+    override suspend fun doRequestVacancies(options: HashMap<String, Int>,text: String?): Response {
         // Если подключение к интернету отсутствует
         if (!isConnected) {
             return Response().apply { resultCode = ResponseCode.NO_INTERNET.code }
         } else {
             return withContext(Dispatchers.IO) {
                 try {
-                    val response = api.searchVacancies(text)
+                    val response = api.searchVacancies(text = text,options = options)
                     response.apply { resultCode = ResponseCode.SUCCESS.code }
                 } catch (e: HttpException) {
                     Log.w("HttpException", e)

--- a/app/src/main/java/ru/practicum/android/diploma/data/network/RetrofitNetworkClient.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/network/RetrofitNetworkClient.kt
@@ -17,7 +17,7 @@ class RetrofitNetworkClient(
 
     private val isConnected = CheckNetworkConnect.isNetworkAvailable(context)
 
-    override suspend fun doRequestVacancies(options: HashMap<String, Int>,text: String?): Response {
+    override suspend fun doRequestVacancies(text: String?, options: HashMap<String, Int>): Response {
         // Если подключение к интернету отсутствует
         if (!isConnected) {
             return Response().apply { resultCode = ResponseCode.NO_INTERNET.code }

--- a/app/src/main/java/ru/practicum/android/diploma/data/network/RetrofitNetworkClient.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/network/RetrofitNetworkClient.kt
@@ -24,7 +24,7 @@ class RetrofitNetworkClient(
         } else {
             return withContext(Dispatchers.IO) {
                 try {
-                    val response = api.searchVacancies(text = text,options = options)
+                    val response = api.searchVacancies(text = text, options = options)
                     response.apply { resultCode = ResponseCode.SUCCESS.code }
                 } catch (e: HttpException) {
                     Log.w("HttpException", e)

--- a/app/src/main/java/ru/practicum/android/diploma/data/search/VacanciesRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/search/VacanciesRepositoryImpl.kt
@@ -6,7 +6,7 @@ import ru.practicum.android.diploma.data.NetworkClient
 import ru.practicum.android.diploma.data.converters.VacanciesConverter
 import ru.practicum.android.diploma.data.dto.VacanciesResponseDto
 import ru.practicum.android.diploma.domain.Resource
-import ru.practicum.android.diploma.domain.models.Vacancy
+import ru.practicum.android.diploma.domain.models.VacancyResponse
 import ru.practicum.android.diploma.domain.search.api.VacanciesRepository
 import ru.practicum.android.diploma.util.ResponseCode
 
@@ -15,8 +15,8 @@ class VacanciesRepositoryImpl(
     private val networkClient: NetworkClient,
 ) : VacanciesRepository {
 
-    override fun searchVacancies(text: String?): Flow<Resource<List<Vacancy>>> = flow {
-        val response = networkClient.doRequestVacancies(text)
+    override fun searchVacancies(text: String?,options: HashMap<String, Int>): Flow<Resource<VacancyResponse>> = flow {
+        val response = networkClient.doRequestVacancies(text = text, options = options)
 
         when (response.resultCode) {
             ResponseCode.NO_INTERNET.code -> emit(Resource.Error(ResponseCode.NO_INTERNET.code))

--- a/app/src/main/java/ru/practicum/android/diploma/data/search/VacanciesRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/search/VacanciesRepositoryImpl.kt
@@ -14,10 +14,8 @@ class VacanciesRepositoryImpl(
     private val vacanciesConverter: VacanciesConverter,
     private val networkClient: NetworkClient,
 ) : VacanciesRepository {
-
-    override fun searchVacancies(text: String?,options: HashMap<String, Int>): Flow<Resource<VacancyResponse>> = flow {
+    override fun searchVacancies(text: String?, options: HashMap<String, Int>): Flow<Resource<VacancyResponse>> = flow {
         val response = networkClient.doRequestVacancies(text = text, options = options)
-
         when (response.resultCode) {
             ResponseCode.NO_INTERNET.code -> emit(Resource.Error(ResponseCode.NO_INTERNET.code))
 

--- a/app/src/main/java/ru/practicum/android/diploma/domain/models/VacancyResponse.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/models/VacancyResponse.kt
@@ -1,0 +1,8 @@
+package ru.practicum.android.diploma.domain.models
+
+data class VacancyResponse(
+    val found: Int,
+    val items: List<Vacancy>,
+    val page: Int,
+    val pages: Int
+)

--- a/app/src/main/java/ru/practicum/android/diploma/domain/search/api/VacanciesInteractor.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/search/api/VacanciesInteractor.kt
@@ -5,5 +5,5 @@ import ru.practicum.android.diploma.domain.Resource
 import ru.practicum.android.diploma.domain.models.VacancyResponse
 
 interface VacanciesInteractor {
-    fun searchVacancies(text: String?,options: HashMap<String, Int>): Flow<Resource<VacancyResponse>>
+    fun searchVacancies(text: String?, options: HashMap<String, Int>): Flow<Resource<VacancyResponse>>
 }

--- a/app/src/main/java/ru/practicum/android/diploma/domain/search/api/VacanciesInteractor.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/search/api/VacanciesInteractor.kt
@@ -5,5 +5,5 @@ import ru.practicum.android.diploma.domain.Resource
 import ru.practicum.android.diploma.domain.models.VacancyResponse
 
 interface VacanciesInteractor {
-    fun searchVacancies(text: String?,options: HashMap<String, Int>): Flow<Resource<List<Vacancy>>>
+    fun searchVacancies(text: String?,options: HashMap<String, Int>): Flow<Resource<VacancyResponse>>
 }

--- a/app/src/main/java/ru/practicum/android/diploma/domain/search/api/VacanciesInteractor.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/search/api/VacanciesInteractor.kt
@@ -2,8 +2,8 @@ package ru.practicum.android.diploma.domain.search.api
 
 import kotlinx.coroutines.flow.Flow
 import ru.practicum.android.diploma.domain.Resource
-import ru.practicum.android.diploma.domain.models.Vacancy
+import ru.practicum.android.diploma.domain.models.VacancyResponse
 
 interface VacanciesInteractor {
-    fun searchVacancies(text: String?): Flow<Resource<List<Vacancy>>>
+    fun searchVacancies(text: String?,options: HashMap<String, Int>): Flow<Resource<List<Vacancy>>>
 }

--- a/app/src/main/java/ru/practicum/android/diploma/domain/search/api/VacanciesRepository.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/search/api/VacanciesRepository.kt
@@ -2,8 +2,8 @@ package ru.practicum.android.diploma.domain.search.api
 
 import kotlinx.coroutines.flow.Flow
 import ru.practicum.android.diploma.domain.Resource
-import ru.practicum.android.diploma.domain.models.Vacancy
+import ru.practicum.android.diploma.domain.models.VacancyResponse
 
 interface VacanciesRepository {
-    fun searchVacancies(text: String?): Flow<Resource<List<Vacancy>>>
+    fun searchVacancies(text: String?, options: HashMap<String, Int>): Flow<Resource<VacancyResponse>>
 }

--- a/app/src/main/java/ru/practicum/android/diploma/domain/search/impl/VacanciesInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/search/impl/VacanciesInteractorImpl.kt
@@ -2,14 +2,14 @@ package ru.practicum.android.diploma.domain.search.impl
 
 import kotlinx.coroutines.flow.Flow
 import ru.practicum.android.diploma.domain.Resource
-import ru.practicum.android.diploma.domain.models.Vacancy
+import ru.practicum.android.diploma.domain.models.VacancyResponse
 import ru.practicum.android.diploma.domain.search.api.VacanciesInteractor
 import ru.practicum.android.diploma.domain.search.api.VacanciesRepository
 
 class VacanciesInteractorImpl(
     private val vacanciesRepository: VacanciesRepository
 ) : VacanciesInteractor {
-    override fun searchVacancies(text: String?): Flow<Resource<List<Vacancy>>> {
+    override fun searchVacancies(text: String?,options: HashMap<String, Int>): Flow<Resource<List<Vacancy>>> {
         return vacanciesRepository.searchVacancies(text)
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/domain/search/impl/VacanciesInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/search/impl/VacanciesInteractorImpl.kt
@@ -9,7 +9,7 @@ import ru.practicum.android.diploma.domain.search.api.VacanciesRepository
 class VacanciesInteractorImpl(
     private val vacanciesRepository: VacanciesRepository
 ) : VacanciesInteractor {
-    override fun searchVacancies(text: String?,options: HashMap<String, Int>): Flow<Resource<VacancyResponse>> {
+    override fun searchVacancies(text: String?, options: HashMap<String, Int>): Flow<Resource<VacancyResponse>> {
         return vacanciesRepository.searchVacancies(text, options)
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/domain/search/impl/VacanciesInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/search/impl/VacanciesInteractorImpl.kt
@@ -9,7 +9,7 @@ import ru.practicum.android.diploma.domain.search.api.VacanciesRepository
 class VacanciesInteractorImpl(
     private val vacanciesRepository: VacanciesRepository
 ) : VacanciesInteractor {
-    override fun searchVacancies(text: String?,options: HashMap<String, Int>): Flow<Resource<List<Vacancy>>> {
-        return vacanciesRepository.searchVacancies(text)
+    override fun searchVacancies(text: String?,options: HashMap<String, Int>): Flow<Resource<VacancyResponse>> {
+        return vacanciesRepository.searchVacancies(text, options)
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/search/fragment/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/search/fragment/SearchFragment.kt
@@ -86,7 +86,7 @@ class SearchFragment : Fragment() {
                     val itemsCount = vacancyAdapter?.itemCount
                     if (itemsCount != null) {
                         if (pos >= itemsCount - 1) {
-                            viewModel.onLastItemReached()
+                            viewModel.onLastItemReached(binding.editTextSearch.text.toString())
                         }
                     }
                 }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/search/fragment/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/search/fragment/SearchFragment.kt
@@ -19,7 +19,6 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.databinding.FragmentSearchBinding
 import ru.practicum.android.diploma.domain.common.SearchResult
-import ru.practicum.android.diploma.domain.models.Vacancy
 import ru.practicum.android.diploma.ui.search.viewmodel.SearchViewModel
 import ru.practicum.android.diploma.ui.vacancydetails.fragment.VacancyFragment
 import ru.practicum.android.diploma.util.coroutine.CoroutineUtils

--- a/app/src/main/java/ru/practicum/android/diploma/ui/search/fragment/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/search/fragment/SearchFragment.kt
@@ -81,12 +81,11 @@ class SearchFragment : Fragment() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 super.onScrolled(recyclerView, dx, dy)
                 if (dy > 0) {
-                    val pos = (binding.recyclerViewSearch.layoutManager as LinearLayoutManager).findLastVisibleItemPosition()
+                    val pos = (binding.recyclerViewSearch.layoutManager as LinearLayoutManager)
+                        .findLastVisibleItemPosition()
                     val itemsCount = vacancyAdapter?.itemCount
-                    if (itemsCount != null) {
-                        if (pos >= itemsCount - 1) {
-                            viewModel.onLastItemReached(binding.editTextSearch.text.toString())
-                        }
+                    if (itemsCount != null && pos >= itemsCount - 1) {
+                        viewModel.onLastItemReached(binding.editTextSearch.text.toString())
                     }
                 }
             }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/search/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/search/viewmodel/SearchViewModel.kt
@@ -27,9 +27,9 @@ class SearchViewModel(
     private val vacanciesList = arrayListOf<Vacancy>()
 
     val options: HashMap<String, Int> = HashMap()
-
-    fun searchVacancies() {
     private val openVacancyTrigger = SingleEventLiveData<Long>()
+
+
     fun getVacancyTrigger(): SingleEventLiveData<Long> = openVacancyTrigger
 
     fun clearSearchResults() {
@@ -44,7 +44,7 @@ class SearchViewModel(
 
         viewModelScope.launch {
             vacanciesInteractor
-                .searchVacancies(text,options)
+                .searchVacancies(text, options)
                 .collect { result ->
                     maxPages = result.value?.pages ?: 0
                     vacanciesList.addAll(result.value?.items ?: emptyList())
@@ -54,7 +54,8 @@ class SearchViewModel(
                 }
         }
     }
-}
+
+
     private fun resultHandle(result: Resource<VacancyResponse>) {
         if (result.errorCode != null) {
             if (result.errorCode == -1) {
@@ -76,10 +77,10 @@ class SearchViewModel(
         openVacancyTrigger.value = vacancyId
     }
 
-    fun onLastItemReached() {
+    fun onLastItemReached(text: String?) {
         if (!isNextPageLoading) {
             if (currentPage < maxPages) {
-                searchVacancies()
+                searchVacancies(text)
             }
         }
 

--- a/app/src/main/java/ru/practicum/android/diploma/ui/search/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/search/viewmodel/SearchViewModel.kt
@@ -29,7 +29,6 @@ class SearchViewModel(
     val options: HashMap<String, Int> = HashMap()
     private val openVacancyTrigger = SingleEventLiveData<Long>()
 
-
     fun getVacancyTrigger(): SingleEventLiveData<Long> = openVacancyTrigger
 
     fun clearSearchResults() {
@@ -54,7 +53,6 @@ class SearchViewModel(
                 }
         }
     }
-
 
     private fun resultHandle(result: Resource<VacancyResponse>) {
         if (result.errorCode != null) {

--- a/app/src/main/java/ru/practicum/android/diploma/ui/search/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/search/viewmodel/SearchViewModel.kt
@@ -76,10 +76,8 @@ class SearchViewModel(
     }
 
     fun onLastItemReached(text: String?) {
-        if (!isNextPageLoading) {
-            if (currentPage < maxPages) {
-                searchVacancies(text)
-            }
+        if (!isNextPageLoading && currentPage < maxPages) {
+            searchVacancies(text)
         }
 
     }

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -97,7 +97,6 @@
         android:layout_height="@dimen/dp_0"
         android:layout_marginTop="@dimen/dp_46"
         android:layout_weight="1"
-        android:layout_marginBottom="@dimen/dp_16"
         android:visibility="gone"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintBottom_toTopOf="@id/progress_bar_search"
@@ -125,13 +124,21 @@
         android:layout_width="@dimen/dp_48"
         android:layout_height="@dimen/dp_48"
         android:layout_gravity="center"
-        android:layout_marginBottom="@dimen/dp_72"
+        android:layout_marginTop="@dimen/dp_16"
+        android:layout_marginBottom="@dimen/dp_16"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/bottomBorder"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/recycler_view_search"
-        tools:visibility="visible" />
+        tools:visibility="gone" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/bottomBorder"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_end="56dp" />
 
 
 

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -97,11 +97,13 @@
         android:layout_height="@dimen/dp_0"
         android:layout_marginTop="@dimen/dp_46"
         android:layout_weight="1"
+        android:layout_marginBottom="@dimen/dp_16"
         android:visibility="gone"
-        app:layout_constraintTop_toBottomOf="@id/edit_text_search"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toTopOf="@id/progress_bar_search"
+        app:layout_constraintTop_toBottomOf="@id/edit_text_search"
         tools:ignore="MissingConstraints"
-        tools:itemCount="4"
+        tools:itemCount="20"
         tools:listitem="@layout/item_vacancy"
         tools:visibility="visible" />
 
@@ -123,12 +125,14 @@
         android:layout_width="@dimen/dp_48"
         android:layout_height="@dimen/dp_48"
         android:layout_gravity="center"
-        android:layout_marginVertical="@dimen/dp_16"
+        android:layout_marginBottom="@dimen/dp_72"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/edit_text_search"
+        app:layout_constraintTop_toBottomOf="@id/recycler_view_search"
         tools:visibility="visible" />
+
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -19,7 +19,9 @@
     <dimen name="dp_46">46dp</dimen>
     <dimen name="dp_48">48dp</dimen>
     <dimen name="dp_52">52dp</dimen>
+    <dimen name="dp_56">56dp</dimen>
     <dimen name="dp_64">64dp</dimen>
+    <dimen name="dp_72">72dp</dimen>
     <dimen name="dp_112">112dp</dimen>
     <dimen name="dp_120">120dp</dimen>
     <dimen name="dp_136">136dp</dimen>


### PR DESCRIPTION
1) Добавил в HhApi, в searchVacancies - QueryMap, чтобы из приложения можно было запрашивать страницу, которую хочу увидеть. Нужную нам страницу задаем во ViewModel, и тянем через интерактор->репозиторий в запрос на сервер, поэтому в doRequestVacancies(options: HashMap<String, Int>) появилось option - как раз нужная нам страница 

2) Создал новую модель VacancyResponse, поля которой такие же, как и у VacancyResponseDto. Это было сделано для того, чтобы после одного запроса на сервер получить сразу максимум страниц. И поменял сразу конвертер, чтобы тот возвращал не List<Vacancy>, а VacancyResponse, вместе с максимумом страниц 

3) В файлах верстки завязал друг на друге RecycleView и ProgressBar. Благодаря этому, когда RecycleView на экране нет и идет поиск, ProgressBar находится по центру экрана, а когда подгружаются новые вакансии, то ProgressBar находится уже внизу 

4) Сделал "пагинацию": теперь вакансии подгружаются по 20 штук, и как только пользователь доходит до конца списка, то начинается подгружаться новый. Как реализовал:
Во ViewModel объявил 4 переменные:
-currentPage - текущая страница, которую отправляем на сервер, а после получения результата прибавляем к ней +1, чтобы при следующем обращении к серверу возвращать новую страницу 

-maxPages - максимальное число страниц

-isNextPageLoading - булевская переменная, которая отвечает за то, чтобы onLastItemReached не вызывалась, пока ответ с сервера еще не пришел 

-vacanciesList - список вакансий, в который добавляются новые вакансии по мере загрузки 

В SearchFragment добавил addOnScrollListener, чтобы отслеживать скролл пользователя. Подробнее о его работе можно прочитать тут: 
https://practicum.yandex.ru/learn/android-developer/courses/8e512d47-6da3-4ab6-8464-aff40d0c0a31/sprints/257978/topics/174a1fab-ce65-4a2f-a606-4f543d30c754/lessons/e56b5398-c90a-4488-9b3e-291ddc382888/