### PR TITLE
Исправлен краш на экране "Выбор страны" в случае отсутствия интернета

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/country/fragment/FilterCountryFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/country/fragment/FilterCountryFragment.kt
@@ -42,6 +42,8 @@ class FilterCountryFragment : Fragment() {
             findNavController().popBackStack()
         }
 
+        viewModel.searchCountries()
+
         val onClick: (String, String) -> Unit =
             { countryId: String, countryName: String -> viewModel.onItemClicked(countryId, countryName) }
         adapter = CountryAdapter(onClick)

--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/country/viewmodel/FilterCountryViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/country/viewmodel/FilterCountryViewModel.kt
@@ -15,10 +15,6 @@ class FilterCountryViewModel(
     private val interactor: AreasInteractor
 ) : ViewModel() {
 
-    init {
-        searchCountries()
-    }
-
     private val selectCountryTrigger = SingleEventLiveData<Pair<String, String>>()
     fun selectCountryTrigger(): SingleEventLiveData<Pair<String, String>> = selectCountryTrigger
 
@@ -31,7 +27,7 @@ class FilterCountryViewModel(
         selectCountryTrigger.value = Pair(first = countryId, second = countryName)
     }
 
-    private fun searchCountries() {
+    fun searchCountries() {
         viewModelScope.launch {
             interactor
                 .getCountries()


### PR DESCRIPTION
Был исправлен краш: 

Краш. Окружение: эмулятор Pixel 6, 33 Api
Кейс: перейти на экран "Выбор страны" -> выключить интернет на устройстве -> выбрать пункт "Страна"
ОР: открылся экран выбора страны с заглушкой
ФР: произошёл краш.