### PR TITLE
Task-144: Устранен баг на экране "Поиск" в случае очистки поля вода с помощью клавиатуры

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/ui/search/fragment/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/search/fragment/SearchFragment.kt
@@ -132,6 +132,7 @@ class SearchFragment : Fragment() {
                 searchText = binding.editTextSearch.text.toString()
                 if (s.isNullOrEmpty()) {
                     CoroutineUtils.debounceJob?.cancel()
+                    renderSearchResult(SearchResult.Empty)
                 }
             }
         }


### PR DESCRIPTION
Баг. Окружение: эмулятор Pixel 6, 33 Api
Кейс: перейти на экран "Поиск" -> выполнить поиск -> появился результат поиска(список вакансий, заглушка "Нет результатов" или "Нет интернета") -> стереть запрос с помощью клавиатуры
ОР: последний результат поиска скрывается
ФР: последний результат поиска остался на экране. Из-за того что список вакансий остаётся на экране его можно скролить. Если начать это делать, то будет искаться вакансии по пустой строке, то есть в результатах начнут отображаться все доступные вакансии.